### PR TITLE
Fixed small buffer in get_datetime()

### DIFF
--- a/slstatus.c
+++ b/slstatus.c
@@ -143,13 +143,13 @@ char *
 get_datetime()
 {
     time_t tm;
-    size_t bufsize = 19;
+    size_t bufsize = 64;
     char *buf = malloc(bufsize);
 
     /* get time in format */
     time(&tm);
     if(!strftime(buf, bufsize, timeformat, localtime(&tm))) {
-        fprintf(stderr, "Strftime failed.\n");
+      fprintf(stderr, "Strftime failed.\n");
         exit(1);
     }
 


### PR DESCRIPTION
The buffer being hardcoded to 19 (the size expected from the default time format),
strftime() would fail on any format returning a longer buffer.
Changed it from 19 to 64 to accomodate longer formats.