### PR TITLE
minor cleanups and sanity checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ options:
 
 ${OBJ}: config.h config.mk
 
-config.h:
+config.h: config.def.h
 	@echo creating $@ from config.def.h
 	@cp config.def.h $@
 

--- a/config.def.h
+++ b/config.def.h
@@ -17,6 +17,9 @@ static const char batteryfullfile[] = "/sys/class/power_supply/BAT0/energy_full_
 /* time */
 static const char timeformat[] = "%y-%m-%d %H:%M:%S";
 
+/* bar update interval in seconds */
+static unsigned int update_interval = 10;
+
 /* statusbar
 Possible arguments:
 - battery (battery percentage)

--- a/config.mk
+++ b/config.mk
@@ -15,7 +15,7 @@ INCS = -I. -I/usr/include -I${X11INC}
 LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lasound
 
 # flags
-CPPFLAGS = -DVERSION=\"${VERSION}\"
+CPPFLAGS = -DVERSION=\"${VERSION}\" -D_GNU_SOURCE
 CFLAGS = -g -std=c99 -pedantic -Wall -O0 ${INCS} ${CPPFLAGS}
 #CFLAGS = -std=c99 -pedantic -Wall -Os ${INCS} ${CPPFLAGS}
 LDFLAGS = -g ${LIBS}

--- a/slstatus.c
+++ b/slstatus.c
@@ -40,21 +40,10 @@ char *
 smprintf(char *fmt, ...)
 {
     va_list fmtargs;
-    char *ret;
-    int len;
-
+    char *ret = NULL;
     va_start(fmtargs, fmt);
-    len = vsnprintf(NULL, 0, fmt, fmtargs);
-    va_end(fmtargs);
-
-    ret = malloc(++len);
-    if (ret == NULL) {
-        fprintf(stderr, "Malloc error.");
-        exit(1);
-    }
-
-    va_start(fmtargs, fmt);
-    vsnprintf(ret, len, fmt, fmtargs);
+    if (vasprintf(&ret, fmt, fmtargs) < 0)
+        return NULL;
     va_end(fmtargs);
 
     return ret;

--- a/slstatus.c
+++ b/slstatus.c
@@ -343,6 +343,7 @@ main()
         free(ram_usage);
         free(volume);
         free(wifi_signal);
+        sleep(update_interval);
     }
 
     /* close display */

--- a/slstatus.c
+++ b/slstatus.c
@@ -79,7 +79,7 @@ get_battery()
     /* open battery now file */
     if (!(fp = fopen(batterynowfile, "r"))) {
         fprintf(stderr, "Error opening battery file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read value */
@@ -91,7 +91,7 @@ get_battery()
     /* open battery full file */
     if (!(fp = fopen(batteryfullfile, "r"))) {
         fprintf(stderr, "Error opening battery file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read value */
@@ -117,7 +117,7 @@ get_cpu_temperature()
     /* open temperature file */
     if (!(fp = fopen(tempfile, "r"))) {
         fprintf(stderr, "Could not open temperature file.\n");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* extract temperature */
@@ -141,7 +141,7 @@ get_cpu_usage()
     /* open stat file */
     if (!(fp = fopen("/proc/stat","r"))) {
         fprintf(stderr, "Error opening stat file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read values */
@@ -156,7 +156,7 @@ get_cpu_usage()
     /* open stat file */
     if (!(fp = fopen("/proc/stat","r"))) {
         fprintf(stderr, "Error opening stat file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read values */
@@ -183,8 +183,8 @@ get_datetime()
     /* get time in format */
     time(&tm);
     if(!strftime(buf, bufsize, timeformat, localtime(&tm))) {
-      fprintf(stderr, "Strftime failed.\n");
-        exit(1);
+        fprintf(stderr, "Strftime failed.\n");
+        return smprintf("n/a");
     }
 
     /* return time */
@@ -202,7 +202,7 @@ get_ram_usage()
     /* open meminfo file */
     if (!(fp = fopen("/proc/meminfo", "r"))) {
         fprintf(stderr, "Error opening meminfo file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read the values */
@@ -283,7 +283,7 @@ get_wifi_signal()
     /* open wifi file */
     if(!(fp = fopen(path, "r"))) {
         fprintf(stderr, "Error opening wifi operstate file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* read the status */
@@ -294,13 +294,13 @@ get_wifi_signal()
 
     /* check if interface down */
     if(strcmp(status, "up\n") != 0){
-        return "n/a";
+        return smprintf("n/a");
     }
 
     /* open wifi file */
     if (!(fp = fopen("/proc/net/wireless", "r"))) {
         fprintf(stderr, "Error opening wireless file.");
-        exit(1);
+        return smprintf("n/a");
     }
 
     /* extract the signal strength */


### PR DESCRIPTION
Please merge following changes.

Summary:
 - do not exit() on errors during fopen(), display "n/a" instead
 - configurable update_interval instead of depending on sleep(1) in get_cpu....
 - minor cleanups (vasprintf instead of calculating the needed buffer len)